### PR TITLE
Configure SPI early in the boot

### DIFF
--- a/Example/LoRaWAN/OTAA_FULL_FUNCTION/OTAA_FULL_FUNCTION.ino
+++ b/Example/LoRaWAN/OTAA_FULL_FUNCTION/OTAA_FULL_FUNCTION.ino
@@ -248,6 +248,11 @@ void setup() {
   sys.config_Get();
   print_wakeup_reason();
 
+  // This is necessary, early in the setup phase, because the ESP32-Arduino SPI
+  // library has default pin assignement - that are NOT those of our board.
+  // We override them here, and all subsequent uses of the SPI library will
+  // use these.
+  SPI.begin(LBT2_SCK, LBT2_MISO, LBT2_MOSI, LBT2_SS);
 // LMIC init
   os_init();
 // Reset the MAC state. Session and pending data transfers will be discarded.

--- a/Example/LoRaWAN/OTAA_FULL_FUNCTION/common.h
+++ b/Example/LoRaWAN/OTAA_FULL_FUNCTION/common.h
@@ -22,6 +22,11 @@
 #define LED_PIN_BLUE    2
 #define LED_PIN_GREEN   15
 
+#define LBT2_SCK  5
+#define LBT2_MISO 19
+#define LBT2_MOSI 27
+#define LBT2_SS   18
+
 class SYS
 {
   public:


### PR DESCRIPTION
When using the standard, unmodified Arduino libraries for ESP32, the SPI library
uses a default set of pins for SPI that are not the same that this board uses.

We thus configure SPI as soon as possible - the library will then "remember" these
settings later on (especially in LMIC - LoRaWan where it is used)