### PR TITLE
Fix platformio config and apply SPI patches for build to work

### DIFF
--- a/Example/LoRaWAN/examples/extras/apply_patches.py
+++ b/Example/LoRaWAN/examples/extras/apply_patches.py
@@ -1,0 +1,23 @@
+from os.path import join, isfile
+
+Import("env")
+
+FRAMEWORK_DIR = env.PioPlatform().get_package_dir("framework-arduinoespressif32")
+patchflag_path = join(FRAMEWORK_DIR, ".patching-done")
+
+# patch file only if we didn't do it before
+if not isfile(join(FRAMEWORK_DIR, ".patching-done")):
+    original_file = join(FRAMEWORK_DIR, "variants", "pico32", "pins_arduino.h")
+    patched_file = join("examples", "extras", "patches", "pico32_dragino_trackerd.patch")
+
+    assert isfile(original_file) and isfile(patched_file)
+
+    env.Execute("patch %s %s" % (original_file, patched_file))
+    # env.Execute("touch " + patchflag_path)
+
+
+    def _touch(path):
+        with open(path, "w") as fp:
+            fp.write("")
+
+    env.Execute(lambda *args, **kwargs: _touch(patchflag_path))

--- a/Example/LoRaWAN/examples/extras/patches/pico32_dragino_trackerd.patch
+++ b/Example/LoRaWAN/examples/extras/patches/pico32_dragino_trackerd.patch
@@ -1,0 +1,10 @@
+20,21c20,21
+< static const uint8_t SS    = 5;
+< static const uint8_t MOSI  = 23;
+---
+> static const uint8_t SS    = 18;
+> static const uint8_t MOSI  = 27;
+23c23
+< static const uint8_t SCK   = 18;
+---
+> static const uint8_t SCK   = 5;

--- a/Example/LoRaWAN/examples/extras/patches/pins_arduino.h
+++ b/Example/LoRaWAN/examples/extras/patches/pins_arduino.h
@@ -1,0 +1,56 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#define EXTERNAL_NUM_INTERRUPTS 16
+#define NUM_DIGITAL_PINS        40
+#define NUM_ANALOG_INPUTS       16
+
+#define analogInputToDigitalPin(p)  (((p)<20)?(esp32_adc2gpio[(p)]):-1)
+#define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
+#define digitalPinHasPWM(p)         (p < 34)
+
+static const uint8_t TX = 1;
+static const uint8_t RX = 3;
+
+static const uint8_t SDA = 21;
+static const uint8_t SCL = 22;
+
+static const uint8_t SS    = 18;
+static const uint8_t MOSI  = 27;
+static const uint8_t MISO  = 19;
+static const uint8_t SCK   = 5;
+
+static const uint8_t A0 = 36;
+static const uint8_t A3 = 39;
+static const uint8_t A4 = 32;
+static const uint8_t A5 = 33;
+static const uint8_t A6 = 34;
+static const uint8_t A7 = 35;
+static const uint8_t A10 = 4;
+static const uint8_t A11 = 0;
+static const uint8_t A12 = 2;
+static const uint8_t A13 = 15;
+static const uint8_t A14 = 13;
+static const uint8_t A15 = 12;
+static const uint8_t A16 = 14;
+static const uint8_t A17 = 27;
+static const uint8_t A18 = 25;
+static const uint8_t A19 = 26;
+
+static const uint8_t T0 = 4;
+static const uint8_t T1 = 0;
+static const uint8_t T2 = 2;
+static const uint8_t T3 = 15;
+static const uint8_t T4 = 13;
+static const uint8_t T5 = 12;
+static const uint8_t T6 = 14;
+static const uint8_t T7 = 27;
+static const uint8_t T8 = 33;
+static const uint8_t T9 = 32;
+
+static const uint8_t DAC1 = 25;
+static const uint8_t DAC2 = 26;
+
+#endif /* Pins_Arduino_h */

--- a/Example/LoRaWAN/platformio.ini
+++ b/Example/LoRaWAN/platformio.ini
@@ -6,7 +6,7 @@
 [platformio]
 default_envs = 
 	dragino_lbt2
-src_dir = OTAA_FULL_FUNCTION
+src_dir = examples/TrackerD
 
 [common]
 monitor_speed = 115200                 ; No need to change this.
@@ -93,3 +93,5 @@ build_flags =
   ${tinygpsplus.build_flags}
   -D BSFILE=\"boards/dragino_lbt2.h\"
   -D LMIC_PRINTF_TO=Serial
+board_build.partitions = huge_app.csv
+extra_scripts = pre:examples/extras/apply_patches.py

--- a/Example/LoRaWAN/platformio.ini
+++ b/Example/LoRaWAN/platformio.ini
@@ -93,5 +93,5 @@ build_flags =
   ${tinygpsplus.build_flags}
   -D BSFILE=\"boards/dragino_lbt2.h\"
   -D LMIC_PRINTF_TO=Serial
-board_build.partitions = huge_app.csv
+board_build.partitions = no_ota.csv
 extra_scripts = pre:examples/extras/apply_patches.py


### PR DESCRIPTION
Overview of changes to make platformio working:

apply_patches.py
Script to automatically patch pins_arduino.h when build. Described in platformio.ini

pico32_dragino_trackerd.patch
Diff file for patch command

pins_arduino.h
Pins according to your wiki for TrackerD, file for offline reference.

platformio.ini
Changes to make examples/TrackerD build and upload correctly with platformio. 
Sometimes the build process excepts on error, when files are built in wrong order. 
When this happens run Build again.

Add project to platformio from projects -> add existing 
Browse to Example/LoRaWAN
Click Open "LoRaWAN"

I have verified these changes to be working and using them at the moment for development. Platformio is easier to edit large projects than Arduino IDE in my opinion.

Thanks for the great product, hopefully able to help with development have few uses for this product.